### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,7 +4,7 @@ author=Hadrián Candela Iglesias
 maintainer=Hadrián Candela Iglesias
 sentence=Atx Power source control functionality for Arduino
 paragraph=This library helps using an Atx Power Source in Arduino projects.
-category=Powering
+category=Device Control
 url=https://github.com/c4ndel4/AtxPower
 architectures=*
 


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Powering' in library AtxPower is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format